### PR TITLE
Fix readme url

### DIFF
--- a/init.gradle
+++ b/init.gradle
@@ -2,7 +2,7 @@
 // in order to respond to 401 auth challenges that may occur when requesting
 // artifacts that have not previously been cached on the server.
 
-// See https://github.com/SpringSource/gradle-init-scripts#readme for details.
+// See https://github.com/spring-projects/gradle-init-scripts/#readme for details.
 
 // Requires Gradle 1.0-milestone-6 or better in order work with newer
 // "maven { url ... }" repository syntax. Will cause errors against earlier


### PR DESCRIPTION
This fixes the readme URL that was still pointing to `SpringSource`

Regarding the `init.gradle` script content itself, it is fine here but not on Artifactory. Following the instruction in the `README`, I get a previous version of that file. Maybe a missing deploy?
